### PR TITLE
Fix numerical data types conversion

### DIFF
--- a/opendocdb-cts/internal/mongosh/fixture_test.go
+++ b/opendocdb-cts/internal/mongosh/fixture_test.go
@@ -38,7 +38,7 @@ func TestConvertFixtures(t *testing.T) { //nolint:revive // exceeds number of li
 				},
 			},
 			expected: `
-			db.c.insertMany([{"_id": "int32", "v": Int32(42)}]);`,
+			db.c.insertMany([{"_id": "int32", "v": 42}]);`,
 		},
 		"Binary": {
 			fixtures: data.Fixtures{

--- a/opendocdb-cts/internal/mongosh/testsuite_test.go
+++ b/opendocdb-cts/internal/mongosh/testsuite_test.go
@@ -32,8 +32,8 @@ func TestConvertRequest(t *testing.T) {
 		"$db", "test",
 	)
 
-	expected := `db.runCommand({"find": "values", "filter": {"v": {"$eq": Int32(42)}}, ` +
-		`"sort": {"_id": Int32(1)}, "$db": "test"});` + "\n"
+	expected := `db.runCommand({"find": "values", "filter": {"v": {"$eq": 42}}, ` +
+		`"sort": {"_id": 1}, "$db": "test"});` + "\n"
 
 	actual, err := ConvertRequest(req)
 	require.NoError(t, err)
@@ -53,7 +53,7 @@ func TestConvertResponse(t *testing.T) {
 	)
 
 	expected := `response = {"cursor": {"firstBatch": [` +
-		`{"_id": "int32-zero", "v": Int32(0)}, ` +
+		`{"_id": "int32-zero", "v": 0}, ` +
 		`{"_id": "int64-zero", "v": Long(0)` +
 		`}], "id": Long(0), "ns": "test.values"}` +
 		`}` + "\n"


### PR DESCRIPTION
Tested manually by
```js
db.test.insertMany([
    {_id: 'd1', v: Double(0.0)},
    {_id: 'd2', v: 0.0},
    {_id: 'i1', v: Int32(0)},
    {_id: 'i2', v: 0},
    {_id: 'l1', v: Long(0)},
]);
```

```
{
  `insert`: `test`,
  `documents`: [
    {
      `_id`: `d1`,
      `v`: 0.0
    },
    {
      `_id`: `d2`,
      `v`: 0
    },
    {
      `_id`: `i1`,
      `v`: 0
    },
    {
      `_id`: `i2`,
      `v`: 0
    },
    {
      `_id`: `l1`,
      `v`: int64(0)
    }
  ]
}
```

Note that `d2` is `int32`.