### PR TITLE
CTS doesn't validate nested arrays

### DIFF
--- a/cts/query/eq.json
+++ b/cts/query/eq.json
@@ -20,6 +20,9 @@
       "cursor": {
         "firstBatch": [
           {
+            "foo": "this test should fail"
+          },
+          {
             "_id": "decimal128-negative-zero",
             "v": {
               "$numberDecimal": "-0.0"


### PR DESCRIPTION
The `cursor.firstBatch` array content seems to not being checked.